### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/flask_classy.py
+++ b/flask_classy.py
@@ -123,7 +123,7 @@ class FlaskView(object):
                         elif len(value._rule_cache[name]) == 1:
                             endpoint = route_name
                         else:
-                            endpoint = "%s_%d" % (route_name, idx,)
+                            endpoint = "{0!s}_{1:d}".format(route_name, idx)
 
                         app.add_url_rule(rule, endpoint, proxy, subdomain=subdomain, **options)
 
@@ -136,13 +136,13 @@ class FlaskView(object):
                     app.add_url_rule(rule, route_name, proxy, methods=methods, subdomain=subdomain)
 
                 else:
-                    route_str = '/%s/' % name
+                    route_str = '/{0!s}/'.format(name)
                     if not cls.trailing_slash:
                         route_str = route_str.rstrip('/')
                     rule = cls.build_rule(route_str, value)
                     app.add_url_rule(rule, route_name, proxy, subdomain=subdomain)
             except DecoratorCompatibilityError:
-                raise DecoratorCompatibilityError("Incompatible decorator detected on %s in class %s" % (name, cls.__name__))
+                raise DecoratorCompatibilityError("Incompatible decorator detected on {0!s} in class {1!s}".format(name, cls.__name__))
 
         if hasattr(cls, "orig_route_base"):
             cls.route_base = cls.orig_route_base
@@ -274,9 +274,9 @@ class FlaskView(object):
                 if arg not in ignored_rule_args:
                     if not query_params or len(args) - i > len(query_params):
                         # This is not optional param, so it's not query argument
-                        rule_parts.append("<%s>" % arg)
+                        rule_parts.append("<{0!s}>".format(arg))
 
-        result = "/%s" % "/".join(rule_parts)
+        result = "/{0!s}".format("/".join(rule_parts))
         return re.sub(r'(/)\1+', r'\1', result)
 
 
@@ -317,7 +317,7 @@ class FlaskView(object):
 
         :param method_name: the method name to use when building a route name
         """
-        return cls.__name__ + ":%s" % method_name
+        return cls.__name__ + ":{0!s}".format(method_name)
 
 
 def get_interesting_members(base_class, cls):

--- a/test_classy/view_classes.py
+++ b/test_classy/view_classes.py
@@ -31,7 +31,7 @@ class BasicView(FlaskView):
         return "Custom Method"
 
     def custom_method_with_params(self, p_one, p_two):
-        return "Custom Method %s %s" % (p_one, p_two,)
+        return "Custom Method {0!s} {1!s}".format(p_one, p_two)
 
     @route("/routed/")
     def routed_method(self):
@@ -99,7 +99,7 @@ class VarBaseView(FlaskView):
 
     @route('/local/<route_local>', methods=['GET'])
     def with_route_arg(self, route, route_local):
-        return "%s %s" % (route, route_local)
+        return "{0!s} {1!s}".format(route, route_local)
 
 class BeforeRequestView(FlaskView):
 
@@ -308,7 +308,7 @@ class TrailingSlashView(FlaskView):
         return "Custom Method"
 
     def custom_method_with_params(self, p_one, p_two):
-        return "Custom Method %s %s" % (p_one, p_two,)
+        return "Custom Method {0!s} {1!s}".format(p_one, p_two)
 
     @route("/routed/")
     def routed_method(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:teracyhq:flask-classy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:teracyhq:flask-classy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)